### PR TITLE
feat: Implement OTP login and address related issues

### DIFF
--- a/Church_Management_System_Client26255/src/model/Accounts.java
+++ b/Church_Management_System_Client26255/src/model/Accounts.java
@@ -2,7 +2,8 @@ package model;
 
 import java.sql.Timestamp; // Or java.time.LocalDateTime
 
-public class Accounts {
+public class Accounts implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
     private int accountId;
     private String username;
     // Password hash should generally not be sent to client, but role might be useful

--- a/Church_Management_System_Client26255/src/service/EventService.java
+++ b/Church_Management_System_Client26255/src/service/EventService.java
@@ -1,14 +1,14 @@
 package service;
 
+import java.rmi.Remote;
 import java.rmi.RemoteException;
 import model.Event;
 import java.util.List;
 import java.sql.Date; // For Member birthdate
 import java.sql.Timestamp; // For Event eventDateTime & EventAttendance checkInTime
-import model.Event;
 import model.Member;
 
-public interface EventService {
+public interface EventService extends java.rmi.Remote {
     public String  registerEvent(Event events) throws RemoteException;
     public  String  updateEvent(Event events) throws RemoteException;
     public  String  deleteEvent(Event events) throws RemoteException;

--- a/Church_Management_System_Server26255/src/model/Accounts.java
+++ b/Church_Management_System_Server26255/src/model/Accounts.java
@@ -4,7 +4,9 @@ import javax.persistence.*;
 
 @Entity
 @Table(name = "accounts") // Assuming table name
-public class Accounts {
+public class Accounts implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L; // You can use any long value
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Church_Management_System_Server26255/src/service/EventService.java
+++ b/Church_Management_System_Server26255/src/service/EventService.java
@@ -1,14 +1,14 @@
 package service;
 
+import java.rmi.Remote;
 import java.rmi.RemoteException;
 import model.Event;
 import java.util.List;
 import java.sql.Date; // For Member birthdate
 import java.sql.Timestamp; // For Event eventDateTime & EventAttendance checkInTime
-import model.Event;
 import model.Member;
 
-public interface EventService {
+public interface EventService extends java.rmi.Remote {
     public String  registerEvent(Event events) throws RemoteException;
     public  String  updateEvent(Event events) throws RemoteException;
     public  String  deleteEvent(Event events) throws RemoteException;

--- a/Church_Management_System_Server26255/src/service/implementation/AccountsServiceImpl.java
+++ b/Church_Management_System_Server26255/src/service/implementation/AccountsServiceImpl.java
@@ -17,11 +17,27 @@ import java.time.temporal.ChronoUnit;
 // import model.Member; // No longer needed after removing getMemberById
 import util.EmailUtil; // Added for email sending
 import util.PasswordUtil; // Added for password hashing
+import java.util.Map;
+import java.util.HashMap;
 
 
 public class AccountsServiceImpl extends UnicastRemoteObject implements AccountsService {
 
     private AccountsDao accountsDao;
+
+    // Inner class for storing OTP data
+    private static class PendingOtpData {
+        String otpCode;
+        Timestamp expiryTime;
+
+        PendingOtpData(String otpCode, Timestamp expiryTime) {
+            this.otpCode = otpCode;
+            this.expiryTime = expiryTime;
+        }
+    }
+
+    // Static map for temporary OTP storage
+    private static final Map<String, PendingOtpData> pendingOtps = new HashMap<>();
 
     public AccountsServiceImpl() throws RemoteException{
         super();
@@ -73,18 +89,10 @@ public class AccountsServiceImpl extends UnicastRemoteObject implements Accounts
     @Override
     public String requestOtp(String username) throws RemoteException {
         if (username == null || username.trim().isEmpty()) {
-            return "Error: Username cannot be empty.";
+            return "Error: Email address cannot be empty.";
         }
-        if (this.accountsDao == null) {
-            System.err.println("AccountsServiceImpl.requestOtp: accountsDao is null!");
-            throw new RemoteException("Account service is not properly initialized.");
-        }
-
-        Accounts account = this.accountsDao.getAccountByUsername(username);
-
-        if (account == null) {
-            return "Error: User not found.";
-        }
+        // The 'username' parameter is treated as the email address.
+        String email = username.trim();
 
         // Generate OTP
         SecureRandom random = new SecureRandom();
@@ -94,62 +102,127 @@ public class AccountsServiceImpl extends UnicastRemoteObject implements Accounts
         // Set OTP expiry time (e.g., 5 minutes from now)
         Timestamp otpExpiryTime = Timestamp.from(Instant.now().plus(5, ChronoUnit.MINUTES));
 
-        // Update OTP in database
-        // This assumes Accounts model has setOtpCode and setOtpExpiryTime methods
-        String updateStatus = this.accountsDao.updateOtpForAccount(account.getAccountId(), otpCode, otpExpiryTime);
-
-        if (!updateStatus.startsWith("OTP details updated successfully")) {
-            return "Error: Could not store OTP details. " + updateStatus;
+        // Store OTP temporarily
+        synchronized (pendingOtps) { // Synchronize access to the map
+            pendingOtps.put(email, new PendingOtpData(otpCode, otpExpiryTime));
         }
 
         // Send email with OTP
-        // The username field is assumed to be the email address for the account
-        boolean emailSent = EmailUtil.sendOtpEmail(account.getUsername(), otpCode);
+        boolean emailSent = EmailUtil.sendOtpEmail(email, otpCode);
 
         if (emailSent) {
-            return "OTP has been sent to your registered email address.";
+            return "OTP has been sent to " + email + ".";
         } else {
-            // Even if email fails, OTP is stored. For critical systems, might rollback or have retry.
-            // For now, inform user of email failure but OTP is technically set.
-            // Consider logging this failure more robustly on the server.
-            return "OTP generated and stored, but failed to send email. Please contact support or check your email server configuration.";
+            // If email sending fails, we might want to remove the OTP from pendingOtps
+            // or let it expire naturally to avoid confusion. For now, let it expire.
+            // Log this failure robustly on the server.
+            System.err.println("Failed to send OTP email to " + email + " for OTP " + otpCode);
+            return "OTP generated, but failed to send email. Please check server logs or contact support.";
         }
     }
 
     @Override
     public Accounts verifyOtpAndLogin(String username, String otp) throws RemoteException {
-        if (username == null || username.trim().isEmpty() ||
-            otp == null || otp.trim().isEmpty()) {
-            throw new RemoteException("Username and OTP cannot be empty.");
+        if (username == null || username.trim().isEmpty() || otp == null || otp.trim().isEmpty()) {
+            // Consider throwing an IllegalArgumentException or returning a specific error DTO
+            // For now, returning null or throwing RemoteException for simplicity with RMI.
+            System.err.println("verifyOtpAndLogin: Username or OTP is empty.");
+            return null; // Or throw new RemoteException("Username and OTP cannot be empty.");
         }
+        String email = username.trim();
+        String providedOtp = otp.trim();
+
+        // 1. Verify OTP from temporary storage
+        PendingOtpData storedOtpData;
+        synchronized (pendingOtps) { // Synchronize access
+            storedOtpData = pendingOtps.get(email);
+        }
+
+        if (storedOtpData == null) {
+            System.err.println("verifyOtpAndLogin: No OTP found for email: " + email);
+            return null; // OTP not found for this email (maybe never requested or already used/expired from map)
+        }
+
+        if (!storedOtpData.otpCode.equals(providedOtp)) {
+            System.err.println("verifyOtpAndLogin: Provided OTP does not match stored OTP for email: " + email);
+            // Optional: Implement attempt counter / OTP invalidation after too many failed attempts for an email
+            return null; // OTP mismatch
+        }
+
+        if (Timestamp.from(Instant.now()).after(storedOtpData.expiryTime)) {
+            System.err.println("verifyOtpAndLogin: OTP expired for email: " + email);
+            synchronized (pendingOtps) { // Synchronize access
+                pendingOtps.remove(email); // Remove expired OTP
+            }
+            return null; // OTP expired
+        }
+
+        // OTP is valid, remove it from temporary storage to prevent reuse
+        synchronized (pendingOtps) { // Synchronize access
+            pendingOtps.remove(email);
+        }
+
+        // 2. Account Handling: Check if account exists or create a new one
         if (this.accountsDao == null) {
             System.err.println("AccountsServiceImpl.verifyOtpAndLogin: accountsDao is null!");
-            throw new RemoteException("Account service is not properly initialized.");
+            throw new RemoteException("Account service is not properly initialized for DAO access.");
         }
 
-        Accounts account = this.accountsDao.getAccountByUsername(username);
+        Accounts account = this.accountsDao.getAccountByUsername(email);
 
-        if (account == null) {
-            return null; // User not found
+        if (account != null) {
+            // Account exists, login successful
+            System.out.println("Existing user logged in: " + email);
+            return account;
+        } else {
+            // Account does not exist, create a new one
+            System.out.println("New user registration via OTP: " + email);
+            Accounts newAccount = new Accounts();
+            newAccount.setUsername(email);
+            newAccount.setRole("USER"); // Set a default role
+
+            // Generate a strong, random password for the password_hash field
+            // as the schema requires it to be not null. This password won't be used by the user.
+            SecureRandom sr = new SecureRandom();
+            byte[] randomBytes = new byte[32]; // Generate 32 random bytes
+            sr.nextBytes(randomBytes);
+            String randomPassword = new java.math.BigInteger(1, randomBytes).toString(16); // Convert to hex string
+
+            String hashedPassword = PasswordUtil.hashPassword(randomPassword);
+            if (hashedPassword == null) {
+                // This should ideally not happen if PasswordUtil is robust
+                System.err.println("verifyOtpAndLogin: Failed to hash generated password for new user: " + email);
+                throw new RemoteException("Failed to create new user account due to password hashing error.");
+            }
+            newAccount.setPasswordHash(hashedPassword);
+
+            // Set OTP fields to null for new accounts as OTP has been consumed
+            newAccount.setOtpCode(null);
+            newAccount.setOtpExpiryTime(null);
+
+            String registrationStatus = this.accountsDao.registerAccounts(newAccount);
+            if (registrationStatus.toLowerCase().startsWith("error")) {
+                 System.err.println("verifyOtpAndLogin: Failed to register new account for " + email + ": " + registrationStatus);
+                 // If registration fails, the user is not logged in.
+                 // Depending on the error, you might throw an exception or return null.
+                 // For instance, if the error is due to a unique constraint violation (shouldn't happen if getAccountByUsername was accurate)
+                 // or other DB issues.
+                 return null;
+            }
+
+            // After successful registration, refetch the account to get the accountId generated by the DB
+            // or ensure registerAccounts populates it (JPA usually does).
+            // For simplicity, assuming registerAccounts populates the ID or we can retrieve it.
+            // If AccountsDao.registerAccounts returns the saved entity or its ID, that would be better.
+            // For now, let's re-fetch. This is not ideal for performance.
+            Accounts registeredAccount = this.accountsDao.getAccountByUsername(email);
+            if(registeredAccount == null){
+                 System.err.println("verifyOtpAndLogin: Critical error. Account for " + email + " registered but could not be retrieved immediately.");
+                 // This case should be rare but indicates a potential issue in DAO or transaction handling.
+                 return null;
+            }
+            System.out.println("New user registered and logged in: " + email + " with Account ID: " + registeredAccount.getAccountId());
+            return registeredAccount;
         }
-
-        // Step 2: Verify OTP (existing logic)
-        // Assumes Accounts model has getOtpCode() and getOtpExpiryTime()
-        String storedOtp = account.getOtpCode();
-        Timestamp otpExpiryTime = account.getOtpExpiryTime();
-
-        if (storedOtp == null || storedOtp.trim().isEmpty() || !storedOtp.equals(otp)) {
-            return null; // OTP does not match or not found
-        }
-
-        if (otpExpiryTime == null || Timestamp.from(Instant.now()).after(otpExpiryTime)) {
-            // OTP has expired
-            this.accountsDao.updateOtpForAccount(account.getAccountId(), null, null); // Clear expired OTP
-            return null;
-        }
-
-        // OTP is valid and not expired
-        this.accountsDao.updateOtpForAccount(account.getAccountId(), null, null); // Clear used OTP
-        return account; // Return the full account object
     }
 }


### PR DESCRIPTION
Key changes:
- Implemented OTP-first registration/login:
  - NewLoginForm modified for OTP-only input.
  - AccountsServiceImpl updated:
    - requestOtp: Generates OTP, stores in memory, sends email.
    - verifyOtpAndLogin: Validates OTP; logs in existing user or registers and logs in new user (with random generated password hash).
- Resolved NotSerializableException for model.Accounts by making it implement java.io.Serializable on client and server.
- Addressed ClassCastException for service.EventService by ensuring the interface extends java.rmi.Remote on client and server.
- I guided you through Hibernate schema generation for the 'accounts' table.

Identified further issues:
- EventImpl.java has an uninitialized eventDao (will cause NPE).
- Other service interfaces need to be checked/updated to extend java.rmi.Remote.
- 'groups' table name is a MySQL reserved keyword.

This commit includes the progress up to modifying EventService.java. The NPE in EventImpl and the review of other service interfaces are the immediate next steps.